### PR TITLE
Case insensitive misuse rule checking for improving detection accuracy

### DIFF
--- a/main/src/main/java/main/rule/base/PatternMatcherRuleChecker.java
+++ b/main/src/main/java/main/rule/base/PatternMatcherRuleChecker.java
@@ -72,7 +72,8 @@ public abstract class PatternMatcherRuleChecker extends BaseRuleChecker {
                 boolean found = false;
 
                 for (String regex : getPatternsToMatch()) {
-                    if (usebox.getValue().toString().matches(regex)) {
+//                     if (usebox.getValue().toString().matches(regex)) {
+                    if(Pattern.compile(regex,Pattern.CASE_INSENSITIVE).matcher(usebox.getValue().toString()).matches()) {
                         putIntoMap(predictableSourcMap, e, usebox.getValue().toString());
                         found = true;
                         break;


### PR DESCRIPTION
CryptoGuard currently has this in `checkForMatchInternal` method under `PatternMatcherRuleChecker` class: 

```java
for (String regex : getPatternsToMatch()) {
                    if (usebox.getValue().toString().matches(regex)) {
                        putIntoMap(predictableSourcMap, e, usebox.getValue().toString());
                        found = true;
                        break;
                    }
                }
```

Whereas the `getPatternsToMatch()` comes from `PatternMatcherRuleChecker` abstract class; and further implemented in `BrokenCryptoFinder`, `BrokenHashFinder` and `HttpUrlFinder`.

The core issue is that the patterns are being checked in a case sensitive manner. As a result, even though `Cipher.getInstance("DES")` will trigger a Rule 1 violation warning, `Cipher.getInstance("des")` will result in a different warning related to Rule 1a. Java `Cipher` class accepts all possible cases as it internally converts it to Upper Case. For example, `Cipher` class under `JDK 7` has this line that allows converting user-defined transformation string to UpperCase.

```java
private static Cipher.Transform getTransform(Service var0, List<Cipher.Transform> var1) {
String var2 = var0.getAlgorithm().toUpperCase(Locale.ENGLISH);
...
        }
```

One way to solve this is to redefine regular expressions to handle case sensitivity. However, that approach will result in redefining _all_ regular expressions.

The other way is to change how the regular expression is being checked; which is what I am proposing through the pull request here.

```java
for (String regex : getPatternsToMatch()) {
                	if(Pattern.compile(regex,Pattern.CASE_INSENSITIVE).matcher(usebox.getValue().toString()).matches()) {
                        putIntoMap(predictableSourcMap, e, usebox.getValue().toString());
                        found = true;
                        break;
                    }
                }
```

The change now allows checking the predefined patterns while ignoring case of the defined pattern.